### PR TITLE
README.md: Link to GNU project page on copyleft

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # copywrong
 
-A list of software that was once free and is now proprietary --- i.e. [free software](http://www.gnu.org/philosophy/free-sw.en.html) that wasn't [copyleft](https://en.wikipedia.org/wiki/Copyleft), and some entity later (and legally) made binary-only releases under a non-free license. The counter examples of [formerly proprietary software](https://en.wikipedia.org/wiki/List_of_formerly_proprietary_software).
+A list of software that was once free and is now proprietary --- i.e. [free software](http://www.gnu.org/philosophy/free-sw.en.html) that wasn't [copyleft](https://www.gnu.org/copyleft/), and some entity later (and legally) made binary-only releases under a non-free license. The counter examples of [formerly proprietary software](https://en.wikipedia.org/wiki/List_of_formerly_proprietary_software).
 
 Please add to this list by sending a Pull Request (if you don't know what that means, just click on the `README.md` then `edit`)
 


### PR DESCRIPTION
Given the purpose of this repository, the GNU project's explanation is significantly more useful than Wikipedia's.  We don't need a neutral point of view here.